### PR TITLE
Forward test: Padding for forward test to avoid rotary embedding error

### DIFF
--- a/train/scripts/step3_upload_pretrained_model/test_forward_megatron_ds.py
+++ b/train/scripts/step3_upload_pretrained_model/test_forward_megatron_ds.py
@@ -394,19 +394,29 @@ if __name__ == "__main__":
 
     print(model)
 
-    tokens = torch.tensor([[    1, 20811,   349,   396, 13126,   369, 13966,   264]], device=torch.cuda.current_device())
+    # Prepare input tensors and pad them for the size of 2048.
+    tokens = torch.tensor([[1, 20811, 349, 396, 13126, 369, 13966, 264]], device=torch.cuda.current_device())
+    tokens = torch.nn.functional.pad(tokens, (0, 2040), value=0)
+    
     position_ids = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7]], device=torch.cuda.current_device())
+    position_ids = torch.nn.functional.pad(position_ids, (0, 2040), value=0)
+    
     loss_mask = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1]], device=torch.cuda.current_device())
-    attention_mask = torch.tensor([[[[False,  True,  True,  True,  True,  True,  True,  True],
-              [False, False,  True,  True,  True,  True,  True,  True],
-              [False, False, False,  True,  True,  True,  True,  True],
-              [False, False, False, False,  True,  True,  True,  True],
-              [False, False, False, False, False,  True,  True,  True],
-              [False, False, False, False, False, False,  True,  True],
-              [False, False, False, False, False, False, False,  True],
-              [False, False, False, False, False, False, False, False]]]], device=torch.cuda.current_device())
+    loss_mask = torch.nn.functional.pad(loss_mask, (0, 2040), value=0)
+    
+    attention_mask = torch.tensor([[[[False, True, True, True, True, True, True, True],
+                                     [False, False, True, True, True, True, True, True],
+                                     [False, False, False, True, True, True, True, True],
+                                     [False, False, False, False, True, True, True, True],
+                                     [False, False, False, False, False, True, True, True],
+                                     [False, False, False, False, False, False, True, True],
+                                     [False, False, False, False, False, False, False, True],
+                                     [False, False, False, False, False, False, False, False]]]], device=torch.cuda.current_device())
+    attention_mask = torch.nn.functional.pad(attention_mask, (0, 2040, 0, 0), value=False)
+    
     #labels = torch.tensor([[32000, 32000, 32000, 32000, 32000, 32000, 32000, 32000]], device=torch.cuda.current_device())
     labels = torch.tensor([[20896, 26570, 20896, 21876, 25931, 25931, 20896, 20896]], device=torch.cuda.current_device())
+    labels = torch.nn.functional.pad(labels, (0, 2040), value=-100)
 
     output_tensor = model(tokens, position_ids, attention_mask)
 


### PR DESCRIPTION
Padding for forward test to avoid the following rotary embedding error.
```
Traceback (most recent call last):
  File "/home/ext_hihayash_gmail_com/tmp_scripts/test_forward_megatron_ds.py", line 411, in <module>
    output_tensor = model(tokens, position_ids, attention_mask)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/deepspeed/utils/nvtx.py", line 15, in wrapped_fn
    ret_val = func(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/deepspeed/runtime/engine.py", line 1822, in forward
    loss = self.module(*inputs, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/megatron_core-0.2.0-py3.9.egg/megatron/model/gpt_model.py", line 125, in forward
    lm_output, moe_losses = self.language_model(
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/megatron_core-0.2.0-py3.9.egg/megatron/model/language_model.py", line 552, in forward
    encoder_output, *encoder_moe_losses = self.encoder(
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/megatron_core-0.2.0-py3.9.egg/megatron/model/transformer.py", line 1941, in forward
    hidden_states = layer(
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/megatron_core-0.2.0-py3.9.egg/megatron/model/transformer.py", line 1217, in forward
    self.self_attention(
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1511, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/megatron_core-0.2.0-py3.9.egg/megatron/model/transformer.py", line 777, in forward
    query_layer = apply_rotary_pos_emb(query_layer, q_pos_emb)
  File "/home/ext_hihayash_gmail_com/miniconda3/envs/.venv_train/lib/python3.9/site-packages/megatron_core-0.2.0-py3.9.egg/megatron/model/rotary_pos_embedding.py", line 55, in apply_rotary_pos_emb
    t = (t * freqs.cos().to(t.dtype)) + (_rotate_half(t) * freqs.sin().to(t.dtype))
RuntimeError: The size of tensor a (8) must match the size of tensor b (2048) at non-singleton dimension 0
```

Output after the change:
```
(tensor([[[ 0.0768, -0.6890,  0.0471,  ...,  0.0591, -0.3203, -0.8818],
         [ 0.1891, -0.6895,  0.0478,  ..., -0.1548, -0.1010, -1.0840],
         [ 0.2510, -0.5938,  0.5728,  ..., -0.2251,  0.1190, -1.0654],
         ...,
         [-0.0090,  0.3042,  0.0784,  ..., -0.1180,  0.5610, -0.1796],
         [-0.0092,  0.3035,  0.0781,  ..., -0.1174,  0.5610, -0.1785],
         [-0.0091,  0.3030,  0.0789,  ..., -0.1183,  0.5610, -0.1783]]],
       device='cuda:0', dtype=torch.float16, grad_fn=<TransposeBackward0>), [tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16), tensor(0., device='cuda:0', dtype=torch.float16)])
[2024-04-27 07:06:30,698] [INFO] [launch.py:347:main] Process 783987 exits successfully.
```